### PR TITLE
Fix displaing of Imagery block in selection_details view

### DIFF
--- a/templates/blocks/selection_details.html
+++ b/templates/blocks/selection_details.html
@@ -42,8 +42,8 @@
           <div class="image-container" ng-repeat="image in images">
             <label>
             <input type="checkbox" style="margin-bottom:5px" />
-            <span style="font-size: 16px; font-weight:bold;">{{ image.time }}:</span>
-            <img ng-src="/api/skymorph/image?key={{ image.key }}"/>
+            <span style="font-size: 16px; font-weight:bold;" ng-bind="image.time"></span>
+            <img ng-src="/api/skymorph/image?key=[[image.key]]"/>
             </label>
           </div>
         </div>


### PR DESCRIPTION
In selection_details.html is used curly brackets for interpolations. And it's not work because for app is setted up square brackets for interpolation. Also you are use ng-bind directive.
