### PR TITLE
Remove a duplicate route.

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,10 +55,6 @@ def index():
 def upcoming():
   return render_template('upcoming.html')
 
-@app.route('/3d')
-def view_3d():
-  return render_template('full3d.html', noop=noop_filter)
-
 @app.route('/3d/')
 def view_3d_slash():
   return render_template('full3d.html', noop=noop_filter)


### PR DESCRIPTION
If you add a trailing slash to the end of a route,
going to that route without the trailing slash
will automatically redirect you to the route with the
trailing slash.
