### PR TITLE
Close issue #19

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -65,7 +65,7 @@ hr.top-bottom-divider {
 #webgl-controls {
   position: absolute;
   right: 0;
-  width: 325px;
+  width: 380px;
   height: 23px;
   background-color: #ccc;
   color: #000;

--- a/static/js/3d/main.js
+++ b/static/js/3d/main.js
@@ -392,16 +392,26 @@
     setAttributeNeedsUpdateFlags();
   }
 
-  // camera locking fns
-  function clearLock(set_default_camera) {
-    if (!locked_object) return;
+  // camera locking and releasing fns
+
+  function resetView() {
+    if (locked_object) {
+      locked_object = null;
+    }
+
+    setDefaultCameraPosition();
+    cameraControls.target = new THREE.Vector3(0,0,0);
+    // reset camera pos
+    setNeutralCameraPosition();
+  }
+
+  function doClearLock(set_default_camera) {
 
     if (set_default_camera) {
       setDefaultCameraPosition();
     }
 
     cameraControls.target = new THREE.Vector3(0,0,0);
-
     // restore color and size
     attributes.value_color.value[locked_object_idx] = locked_object_color;
     attributes.size.value[locked_object_idx] = locked_object_size;
@@ -420,7 +430,12 @@
 
     // reset camera pos so subsequent locks don't get into crazy positions
     setNeutralCameraPosition();
-  }   // end clearLock
+  } 
+
+  function clearLock(set_default_camera) {
+    if (!locked_object) return;
+    doClearLock(set_default_camera)
+  }
 
   function setLock(full_name) {
     if (locked_object) {
@@ -721,6 +736,17 @@
     return THREE.ImageUtils.loadTexture(path);
   }
 
+  function resetColors(blacken) {
+
+    if (blacken) {
+      $('#objects-of-interest tr').css('background-color', '#000');
+    }
+
+    $('#sun-selector').css('background-color', 'yellowgreen'); //olivedrab
+    $('#reset-selector').css('background-color', 'dimgray');
+  }
+
+
   /** Public functions **/
 
   me.clearRankings = function() {
@@ -826,29 +852,36 @@
       $('#objects-of-interest tr:gt(2)').remove();
       setTimeout(function() {
         setLock('342843 Davidbowie');
-        $('#sun-selector').css('background-color', 'black');
-        $('#earth-selector').css('background-color', 'green');
+        resetColors()
       }, 0);
 
-    } else {
-      $('#objects-of-interest tr:gt(1)').remove();
+    } 
+    else {
+      $('#objects-of-interest tr:gt(2)').remove();
     }
     $('#objects-of-interest').append(featured_html).on('click', 'tr', function() {
-      $('#objects-of-interest tr').css('background-color', '#000');
       var $e = $(this);
       var full_name = $e.data('full-name');
-      $('#sun-selector').css('background-color', 'green');
+      resetColors()
       switch (full_name) {
         // special case full names
-        case 'sun':
-          clearLock(true);
+
+        case 'reset':
+          doClearLock(true);
+          resetColors(true);
           return false;
+
+        case 'sun':
+          resetView();
+          return false;
+
       }
-      clearLock();
+      // clearLock();
+      resetColors(true)
+      doClearLock();
 
       // set new lock
       $e.css('background-color', 'green');
-      $('#sun-selector').css('background-color', '#000');
       setLock(full_name);
 
       return false;
@@ -879,3 +912,4 @@
     object_movement_on = true;
   };
 }
+

--- a/static/js/3d/main.js
+++ b/static/js/3d/main.js
@@ -60,6 +60,7 @@
     , locked_object_size = -1
     , locked_object_color = -1
 
+  var full_name_temp = null
   // David Bowie special case.
   // Note: If you're updating a featured case here, make sure you update in the
   // full3d.html tempalte too.
@@ -394,24 +395,25 @@
 
   // camera locking and releasing fns
 
-  function resetView() {
-    if (locked_object) {
-      locked_object = null;
-    }
+  function resetView(set_default_camera, clear_lock) {
+    locked_object = null;
 
-    setDefaultCameraPosition();
-    cameraControls.target = new THREE.Vector3(0,0,0);
-    // reset camera pos
-    setNeutralCameraPosition();
-  }
-
-  function doClearLock(set_default_camera) {
-
+    // setDefaultCameraPosition();
     if (set_default_camera) {
       setDefaultCameraPosition();
     }
 
     cameraControls.target = new THREE.Vector3(0,0,0);
+
+    if (clear_lock){
+      dropLock() 
+    }
+
+    // reset camera pos
+    setNeutralCameraPosition();
+  }
+
+  function dropLock(){
     // restore color and size
     attributes.value_color.value[locked_object_idx] = locked_object_color;
     attributes.size.value[locked_object_idx] = locked_object_size;
@@ -427,14 +429,11 @@
     locked_object_idx = -1;
     locked_object_size = -1;
     locked_object_color = null;
-
-    // reset camera pos so subsequent locks don't get into crazy positions
-    setNeutralCameraPosition();
-  } 
+  }
 
   function clearLock(set_default_camera) {
     if (!locked_object) return;
-    doClearLock(set_default_camera)
+    resetView(set_default_camera, true);
   }
 
   function setLock(full_name) {
@@ -742,10 +741,9 @@
       $('#objects-of-interest tr').css('background-color', '#000');
     }
 
-    $('#sun-selector').css('background-color', 'yellowgreen'); //olivedrab
-    $('#reset-selector').css('background-color', 'dimgray');
+    $('#sun-selector').css('background-color', '#0DDD3B'); // 00D32F
+    $('#reset-selector').css('background-color', '#365A3E');
   }
-
 
   /** Public functions **/
 
@@ -765,11 +763,16 @@
     }
   };
 
+  me.resetView = function(clear_lock) {
+    return resetView(true, clear_lock);
+  };
+
   me.clearLock = function() {
     return clearLock(true);
   };
 
   me.setLock = function(full_name) {
+    dropLock();
     return setLock(full_name);
   };
 
@@ -867,18 +870,17 @@
         // special case full names
 
         case 'reset':
-          doClearLock(true);
+          resetView(true, true);
           resetColors(true);
           return false;
 
         case 'sun':
-          resetView();
+          resetView(true, false);
           return false;
-
       }
-      // clearLock();
+
       resetColors(true)
-      doClearLock();
+      resetView(false, true);
 
       // set new lock
       $e.css('background-color', 'green');

--- a/static/js/main/controllers/asterank_3d.js
+++ b/static/js/main/controllers/asterank_3d.js
@@ -1,5 +1,6 @@
 function Asterank3DCtrl($scope, pubsub) {
   $scope.running = true;
+  var selected_object = null
 
   $scope.Init = function() {
     asterank3d = new Asterank3D({
@@ -19,14 +20,21 @@ function Asterank3DCtrl($scope, pubsub) {
         $ls.height($ls.height() + 250);
       },
       top_object_color: 0xffffff
+      // top_object_color: 0xdda0dd
     });
   }
 
+  $scope.ResetView = function() {
+    pubsub.publish('DeselectAsteroid', [selected_object]);
+    asterank3d.resetView(true, pubsub);
+  }
+
   $scope.SunView = function() {
-    asterank3d.clearLock();
+    asterank3d.resetView(false);
   }
 
   $scope.EarthView = function() {
+    pubsub.publish('DeselectAsteroid', [selected_object]);
     asterank3d.setLock('earth');
   }
 
@@ -43,6 +51,10 @@ function Asterank3DCtrl($scope, pubsub) {
   $scope.FullView = function() {
     window.location.href="http://asterank.com/3d";
   }
+
+  pubsub.subscribe('AsteroidDetailsClick', function(asteroid) {
+    selected_object = asteroid
+  });
 
   pubsub.subscribe('Lock3DView', function(asteroid) {
     if (asterank3d.isWebGLSupported()) {

--- a/static/js/main/controllers/asteroid_table.js
+++ b/static/js/main/controllers/asteroid_table.js
@@ -77,6 +77,12 @@ function AsteroidTableCtrl($scope, $http, pubsub) {
 
   } // end UpdateRankings
 
+  // Reset asteroid selection in table and hide asteroid details
+  pubsub.subscribe('DeselectAsteroid', function(obj) {
+    $scope.selected = null;
+    pubsub.publish('AsteroidDetailsClick', [obj]);
+  });
+
   $scope.AsteroidClick = function(obj) {
     if (obj === $scope.selected) {
       // deselect

--- a/templates/blocks/webgl.html
+++ b/templates/blocks/webgl.html
@@ -1,6 +1,7 @@
 <div class="" ng-controller="Asterank3DCtrl" ng-init="Init()">
   <div id="webgl-controls">
     <ul>
+      <li><span ng-click="ResetView()"><i class="icon-refresh"></i> Reset</span></li>
       <li><span ng-click="SunView()"><i class="icon-star-empty"></i> Sun</span></li>
       <li><span ng-click="EarthView()"><i class="icon-home"></i> Earth</span></li>
       <li ng-show="running"><span ng-click="Pause()"><i class="icon-pause"></i> Pause</span></li>

--- a/templates/full3d.html
+++ b/templates/full3d.html
@@ -56,10 +56,10 @@
     <div id="objects-of-interest-container" style="text-align:center;display:none;opacity:.7;">
       <span>Significant objects<br>&amp; estimated value</span>
       <table id="objects-of-interest">
-        <tr id="reset-selector" data-full-name="reset" style="background-color:dimgray; font-weight: bold">
+        <tr id="reset-selector" data-full-name="reset" style="background-color:#365A3E; font-weight: bold">
           <td colspan="2"><a href="#">Reset</a> (default view)</td>
         </tr>
-        <tr id="sun-selector" data-full-name="sun" style="background-color:yellowgreen; font-weight: bold">
+        <tr id="sun-selector" data-full-name="sun" style="background-color:#0DDD3B; font-weight: bold">
           <td colspan="2"><a href="#">Sun</a></td>
         </tr>
         <tr id="earth-selector" data-full-name="earth"> <!-- style="background-color:lightseagreen;" -->

--- a/templates/full3d.html
+++ b/templates/full3d.html
@@ -56,10 +56,14 @@
     <div id="objects-of-interest-container" style="text-align:center;display:none;opacity:.7;">
       <span>Significant objects<br>&amp; estimated value</span>
       <table id="objects-of-interest">
-        <tr id="sun-selector" data-full-name="sun" style="background-color:green;">
-          <td colspan="2"><a href="#">Sun</a> (default view)</td>
+        <tr id="reset-selector" data-full-name="reset" style="background-color:dimgray; font-weight: bold">
+          <td colspan="2"><a href="#">Reset</a> (default view)</td>
         </tr>
-        <tr id="earth-selector" data-full-name="earth">
+        <tr id="sun-selector" data-full-name="sun" style="background-color:yellowgreen; font-weight: bold">
+          <td colspan="2"><a href="#">Sun</a></td>
+        </tr>
+        <tr id="earth-selector" data-full-name="earth"> <!-- style="background-color:lightseagreen;" -->
+
           <td colspan="2"><a href="#">Earth</a></td>
         </tr>
         <tr id="342843-Davidbowie-selector" data-full-name="342843 Davidbowie">


### PR DESCRIPTION
resolve #19. Clicking on Sun button preserves lock on the selected asteroid and doesn't remove its orbit. Add 'Reset' button to deselect asteroid and reset view (can also be helpful to restore view from weird camera angles and scales). Earth selection behaviour is intentionally left unchanged as asteroid tracking can be a bit complicated from the Earth-locked view.